### PR TITLE
Recommend installing the correct compiler version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 If you want to run the examples you'll need to have `cargo` and `rustc` installed:
 
-1. It's recommended that you pin the directory to the `nightly-2018-07-14` compiler so the examples work
-2. `cargo run --bin waker`
-3. `cargo run --bin timer`
-4. `cargo run --bin tiny`
+1. It's recommended that you pin the directory to the correct nightly compiler so
+   the examples work. To do this, create a file `rust-toolchain` with the contents
+   `nightly-2018-08-18` 
+2. `cargo run --bin timer`
+3. `cargo run --bin executor`
 
 ## License
 


### PR DESCRIPTION
If I follow the `README` instructions, I get the following error:

https://gist.github.com/yaymukund/389cf470c0f9987c440a5a32e4f67310

With the help of `dgriffen` in `#rust-beginners`, we figured out that we need `2018-08-18`, so I've updated the README.